### PR TITLE
Support Base64 JWT secrets

### DIFF
--- a/kong/plugins/jwt/access.lua
+++ b/kong/plugins/jwt/access.lua
@@ -83,8 +83,13 @@ function _M.execute(conf)
     return responses.send_HTTP_FORBIDDEN("No credentials found for given '"..conf.secret_key_field.."'")
   end
 
+  local jwt_secret_value = jwt_secret.secret
+  if conf.secret_is_base64 then
+    jwt_secret_value = jwt:b64_decode(jwt_secret_value)
+  end
+
   -- Now verify the JWT signature
-  if not jwt:verify_signature(jwt_secret.secret) then
+  if not jwt:verify_signature(jwt_secret_value) then
     return responses.send_HTTP_FORBIDDEN("Invalid signature")
   end
 

--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -174,6 +174,10 @@ function _M:verify_signature(key)
   return alg_verify[self.header.alg](self.header_64.."."..self.claims_64, self.signature, key)
 end
 
+function _M:b64_decode(input)
+  return b64_decode(input)
+end
+
 --- Registered claims according to RFC 7519 Section 4.1
 local registered_claims = {
   ["nbf"] = {

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -3,6 +3,7 @@ return {
   fields = {
     uri_param_names = {type = "array", default = {"jwt"}},
     secret_key_field = {type = "string", default = "iss"},
+    secret_is_base64 = {type = "boolean", default = false},
     claims_to_verify = {type = "array", enum = {"exp", "nbf"}}
   }
 }


### PR DESCRIPTION
Auth0 generates JWTs signed by a key that is a Base64-encoded binary blob (witness the "secret base64 encoded" checkbox at jwt.io). This patch adds support for such secrets while preserving the status quo by default.

I believe this patch is necessary: decoding the secret provided by Base64 and attempting to use it in its raw form is a non-starter: round-tripping it through UTF-8, as would be necessary using `curl` in a terminal to pass these secrets to Kong APIs, will perturb the byte stream and lead to spurious signature mismatches.
